### PR TITLE
Significant rewrite & bugfixes

### DIFF
--- a/hostname.js
+++ b/hostname.js
@@ -1,32 +1,46 @@
-const title = document.querySelector('title');
-let observer = new MutationObserver(function(mutations) {
-    changeTitle();
-});
-const config = { subtree: true, characterData: true, childList: true };
-let protocolEnabled, pathEnabled, protocol, path;
+let title_element = document.querySelector('head > title');
+let previous = null;
 
-let getting = browser.storage.local.get();
-getting.then(setExtraOptions, e => console.error(error));
-
-observer.observe(title, config);
-window.addEventListener ("load", changeTitle, false);
-
-function setExtraOptions(item) {
-        protocolEnabled = item.protocol;
-        pathEnabled = item.path;
-}
-
-function prepHostname() {
-    protocol = (protocolEnabled ? `${window.location.protocol}//` : "");
-    path = (pathEnabled ? window.location.pathname : "");
-    return ` - ${protocol}${window.location.hostname}${path}`;
-}
-
-function changeTitle() {
-    let hostname = prepHostname();
-    if (!document.title.includes(hostname)) {
-        observer.disconnect();
-        document.title = document.title + hostname;
-        observer.observe(title, config);
+async function render() {
+    let prefs = await get_prefs();
+    switch (prefs.what) {
+        case 'host':
+            return `${prefs.delimiter}${window.location.host}`;
+        case 'origin':
+            return `${prefs.delimiter}${window.location.origin}`;
+        case 'url_noqs':
+            return `${prefs.delimiter}${window.location.origin}${window.location.pathname}`;
+        default:
+            throw new Error('not implemented');
     }
 }
+
+async function changeTitle() {
+    try {
+        let new_part = await render('host');
+        /* using title_element.textContent is better than document.title
+           because it preserves all whitespace characters as-is and
+           it helps to avoid endless loop if configured delimiter contains more than one whitespace in a row */
+        if (title_element.textContent.endsWith(new_part))
+            return;
+        let base = (previous !== null && title_element.textContent.endsWith(previous)) ?
+            title_element.textContent.replace(previous, '') /*TODO: ensure replacement in the end?*/ :
+            title_element.textContent;
+
+        previous = new_part;
+        title_element.textContent = `${base}${new_part}`;
+    } catch (e) {console.error(e)}
+}
+
+
+let observer = new MutationObserver(changeTitle);
+observer.observe(
+    title_element,
+    {
+        subtree: true,
+        characterData: true,
+        childList: true
+    }
+);
+browser.storage.onChanged.addListener(changeTitle);
+changeTitle();

--- a/manifest.json
+++ b/manifest.json
@@ -6,15 +6,23 @@
 
   "description": "Puts the hostname of the tab in the title",
 
+  "applications": {
+    "gecko": {
+      "id": "{b8842ade-9efd-4461-84bd-2106e91854fe}"
+    }
+  },
+
   "content_scripts": [
     {
       "matches": ["*://*/*"],
-      "js": ["hostname.js"],
+      "js": ["storage-wrap.js", "hostname.js"],
       "run_at": "document_end"
     }
   ],
   "options_ui": {
-    "page": "options.html"
+    "page": "options.html",
+    "browser_style": true,
+    "open_in_tab": false
   },
   "permissions": [
      "tabs", "*://*/*", "storage"

--- a/options.html
+++ b/options.html
@@ -2,18 +2,44 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <script src="storage-wrap.js"></script>
+    <style>
+      table,
+      tbody,
+      td > *
+      {
+        width: 100%;
+      }
+      th {
+        text-align: left;
+      }
+      h1 {
+        font-size: 2rem;
+        font-weight: normal;
+      }
+    </style>
   </head>
 
-  <body>
+  <body class="browser-style">
     <h1>Preferences</h1>
-    <p>Note: Changes will only be shown on new tabs, or after restarting Firefox.</p>
-    <form>
-        <input id="protocolEnabled" type="checkbox">
-        <label for="protocolEnabled">Show protocol in title</label>
-        <br /><br />
-        <input id="pathEnabled" type="checkbox">
-        <label for="pathEnabled">Show path in title (does not show query strings)</label>
-    </form>
+    <table>
+      <tbody>
+      <tr>
+        <th><label for="what" class="browser-style-label">Show</label></th>
+        <td class="browser-style">
+          <select id="what" class="browser-style pref">
+            <option value="host">Host (hostname + port)</option>
+            <option value="origin">Origin (protocol + hostname + port)</option>
+            <option value="url_noqs">URL (without querystring)</option>
+          </select>
+        </td>
+      </tr>
+      <tr>
+        <th><label for="delimiter" class="browser-style-label">Delimiter</label></th>
+        <td class="browser-style"><input type="text" id="delimiter" class="browser-style pref"></td>
+      </tr>
+      </tbody>
+    </table>
     <script src="options.js"></script>
   </body>
 </html>

--- a/storage-wrap.js
+++ b/storage-wrap.js
@@ -1,0 +1,15 @@
+const prefs_defaults = {
+    what: "host",
+    delimiter: " - ",
+};
+
+function get_prefs() {
+    return browser.storage.sync.get(prefs_defaults);
+}
+
+function set_pref(pref, value) {
+    if (prefs_defaults[pref] === value)
+        return browser.storage.sync.remove(pref);
+    else
+        return browser.storage.sync.set({[pref]: value});
+}


### PR DESCRIPTION
I've started hacking your add-on to fix annoying bug (see first point below) and eventually end up with some major rewrite.

* fixed bug when no hostname (or whatever) was inserted in title under some circumstances (content script insertion happens after load event)
It's not needed to wait for load event because content script is inserted at `document_end` which means that all DOM is already constructed. Meanwhile, if some script would change title, you have `MutationObserver` for that.
Most obvious example is a page without any external content (stylesheets, images, etc) — in such case it's very likely that load event will fire before content script insertion. However, there are occasional real world pages which are affected by this issue (I suspect, #7 is about that).
* all preferences apply immediately
* configurable delimiter (#2)
* slightly different choices of what to insert
Note: I haven't wrote an updater from previous version of preferences.
* using storage.sync
* added add-on id (extracted actual value from addons.mozilla.org)
* using browser_style: true for options_ui page so it looks more natural inside about:addons UI. However, it has some bug which under some circumstances leads to unreadable text. But there is a workaround for it.